### PR TITLE
Added templating to coredns error to allow for consolidation

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -27,6 +27,8 @@ coredns_default_zone_cache_block: |
 #     answer name (.*)\.svc\.cluster\.local {1}.my.domain
 #   }
 
+# coredns_additional_error_config: |
+#   consolidate 5m ".* i/o timeout$" warning
 
 # dns_upstream_forward_extra_opts apply to coredns forward section as well as nodelocaldns upstream target forward section
 # dns_upstream_forward_extra_opts:

--- a/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/coredns-config.yml.j2
@@ -12,7 +12,11 @@ data:
 {%   for block in coredns_external_zones %}
     {{ block['zones'] | join(' ') }} {
         log
-        errors
+        errors {
+{% if coredns_additional_error_config is defined %}
+          {{ coredns_additional_error_config | indent(width=10, first=False) }}
+{% endif %}
+        }
 {% if block['rewrite'] is defined and block['rewrite'] | length > 0 %}
 {% for rewrite_match in block['rewrite'] %}
         rewrite {{ rewrite_match }}
@@ -31,10 +35,14 @@ data:
 {%   endfor %}
 {% endif %}
     .:53 {
-        {% if coredns_additional_configs is defined %}
+{% if coredns_additional_configs is defined %}
         {{ coredns_additional_configs | indent(width=8, first=False) }}
-        {% endif %}
-        errors
+{% endif %}
+        errors {
+{% if coredns_additional_error_config is defined %}
+          {{ coredns_additional_error_config | indent(width=10, first=False) }}
+{% endif %}
+        }
         health {
             lameduck 5s
         }


### PR DESCRIPTION
**What type of PR is this?**
Allows for configuration of the errors plugin for coredns so that for example consolidation can be used.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/elastisys/compliantkubernetes-apps/issues/1691

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
