### PR TITLE
Support pre-created floating IPs with Terraform in Openstack

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -299,10 +299,10 @@ For your cluster, edit `inventory/$CLUSTER/cluster.tfvars`.
 |`force_null_port_security` | Set `null` instead of `true` or `false` for `port_security`. `false` by default |
 |`k8s_nodes` | Map containing worker node definition, see explanation below |
 |`k8s_masters` | Map containing master node definition, see explanation for k8s_nodes and `sample-inventory/cluster.tfvars` |
-| `k8s_master_loadbalancer_enabled`| Enable and use an Octavia load balancer for the K8s master nodes |
-| `k8s_master_loadbalancer_listener_port` | Define via which port the K8s Api should be exposed. `6443` by default  |
-| `k8s_master_loadbalancer_server_port` | Define via which port the K8S api is available on the mas. `6443` by default |
-| `k8s_master_loadbalancer_public_ip` | Specify if an existing floating IP should be used for the load balancer. A new floating IP is assigned by default  |
+|`k8s_master_loadbalancer_enabled` | Enable and use an Octavia load balancer for the K8s master nodes |
+|`k8s_master_loadbalancer_listener_port` | Define via which port the K8s Api should be exposed. `6443` by default  |
+|`k8s_master_loadbalancer_server_port` | Define via which port the K8S api is available on the master nodes. `6443` by default |
+|`k8s_master_loadbalancer_public_ip` | Specify if an existing floating IP should be used for the load balancer. A new floating IP is assigned by default  |
 
 ##### k8s_nodes
 
@@ -317,7 +317,8 @@ k8s_nodes:
    node-name:
     az: string # Name of the AZ
     flavor: string # Flavor ID to use
-    floating_ip: bool # If floating IPs should be created or not
+    floating_ip: bool # If floating IPs should be used or not
+    reserved_floating_ip: string # If floating_ip is true use existing floating IP, if reserved_floating_ip is an empty string and floating_ip is true, a new floating IP will be created
     extra_groups: string # (optional) Additional groups to add for kubespray, defaults to no groups
     image_id: string # (optional) Image ID to use, defaults to var.image_id or var.image
     root_volume_size_in_gb: number # (optional) Size of the block storage to use as root disk, defaults to var.node_root_volume_size_in_gb or to use volume from flavor otherwise

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -89,11 +89,15 @@ variable "k8s_node_fips" {
 }
 
 variable "k8s_masters_fips" {
-  type = map
+  type = map(object({
+    address = string
+  }))
 }
 
 variable "k8s_nodes_fips" {
-  type = map
+  type = map(object({
+    address = string
+  }))
 }
 
 variable "bastion_fips" {
@@ -136,8 +140,9 @@ variable "k8s_masters" {
   type = map(object({
     az                     = string
     flavor                 = string
-    floating_ip            = bool
     etcd                   = bool
+    floating_ip            = bool
+    reserved_floating_ip   = optional(string)
     image_id               = optional(string)
     root_volume_size_in_gb = optional(number)
     volume_type            = optional(string)
@@ -150,6 +155,7 @@ variable "k8s_nodes" {
     az                     = string
     flavor                 = string
     floating_ip            = bool
+    reserved_floating_ip   = optional(string)
     extra_groups           = optional(string)
     image_id               = optional(string)
     root_volume_size_in_gb = optional(number)

--- a/contrib/terraform/openstack/modules/ips/main.tf
+++ b/contrib/terraform/openstack/modules/ips/main.tf
@@ -15,7 +15,7 @@ resource "openstack_networking_floatingip_v2" "k8s_master" {
 }
 
 resource "openstack_networking_floatingip_v2" "k8s_masters" {
-  for_each   = var.number_of_k8s_masters == 0 && var.number_of_k8s_masters_no_etcd == 0 ? { for key, value in var.k8s_masters : key => value if value.floating_ip } : {}
+  for_each   = var.number_of_k8s_masters == 0 && var.number_of_k8s_masters_no_etcd == 0 ? { for key, value in var.k8s_masters : key => value if value.floating_ip && (lookup(value, "reserved_floating_ip", "") == "") } : {}
   pool       = var.floatingip_pool
   depends_on = [null_resource.dummy_dependency]
 }
@@ -40,7 +40,7 @@ resource "openstack_networking_floatingip_v2" "bastion" {
 }
 
 resource "openstack_networking_floatingip_v2" "k8s_nodes" {
-  for_each   = var.number_of_k8s_nodes == 0 ? { for key, value in var.k8s_nodes : key => value if value.floating_ip } : {}
+  for_each   = var.number_of_k8s_nodes == 0 ? { for key, value in var.k8s_nodes : key => value if value.floating_ip && (lookup(value, "reserved_floating_ip", "") == "") } : {}
   pool       = var.floatingip_pool
   depends_on = [null_resource.dummy_dependency]
 }

--- a/contrib/terraform/openstack/modules/ips/outputs.tf
+++ b/contrib/terraform/openstack/modules/ips/outputs.tf
@@ -1,10 +1,33 @@
+locals {
+  k8s_masters_reserved_fips = {
+    for key, value in var.k8s_masters : key => {
+      address = value.reserved_floating_ip
+    } if value.floating_ip && (lookup(value, "reserved_floating_ip", "") != "")
+  }
+  k8s_masters_create_fips = {
+    for key, value in openstack_networking_floatingip_v2.k8s_masters : key => {
+      address = value.address
+    }
+  }
+  k8s_nodes_reserved_fips = {
+    for key, value in var.k8s_nodes : key => {
+      address = value.reserved_floating_ip
+    } if value.floating_ip && (lookup(value, "reserved_floating_ip", "") != "")
+  }
+  k8s_nodes_create_fips = {
+    for key, value in openstack_networking_floatingip_v2.k8s_nodes : key => {
+      address = value.address
+    }
+  }
+}
+
 # If k8s_master_fips is already defined as input, keep the same value since new FIPs have not been created.
 output "k8s_master_fips" {
   value = length(var.k8s_master_fips) > 0 ? var.k8s_master_fips : openstack_networking_floatingip_v2.k8s_master[*].address
 }
 
 output "k8s_masters_fips" {
-  value = openstack_networking_floatingip_v2.k8s_masters
+  value = merge(local.k8s_masters_create_fips, local.k8s_masters_reserved_fips)
 }
 
 # If k8s_master_fips is already defined as input, keep the same value since new FIPs have not been created.
@@ -17,7 +40,7 @@ output "k8s_node_fips" {
 }
 
 output "k8s_nodes_fips" {
-  value = openstack_networking_floatingip_v2.k8s_nodes
+  value = merge(local.k8s_nodes_create_fips, local.k8s_nodes_reserved_fips)
 }
 
 output "bastion_fips" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR adds support for specifying existing floating IPs on each machine listed in `k8s_nodes` and `k8s_masters` with a new optional variable `reserved_floating_ip` which is only used when the `floating_ip` variable is set to true. If `reserved_floating_ip` is not set and `floating_ip` is true, a new floating IP will be created same as before.

When `reserved_floating_ip` is set, that IP will get released and not deleted when deleting all Terraform resources.

**Known limitations:**
- If you specify the same IP for `reserved_floating_ip` on multiple hosts, Terraform will not complain and only one machine gets assigned the IP in the end, as there is currently no check for whether or not the specific IP has already been assigned. The output will show the same IP several times as well.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/elastisys/compliantkubernetes-kubespray/issues/392

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
