### PR TITLE
create and attach floating IPs to load balalancer

### DIFF
--- a/contrib/terraform/upcloud/README.md
+++ b/contrib/terraform/upcloud/README.md
@@ -115,6 +115,8 @@ terraform destroy --var-file cluster-settings.tfvars \
   * `target_port`: Port to the backend servers.
   * `backend_servers`: List of servers that traffic to the port should be forwarded to.
   * `proxy_protocol`: If the loadbalancer should set up the backend using proxy protocol.
+  * `create_floating_ip`: Create floating IP, managed by Terraform automatically.
+  * `ip_addresses`: Allow attaching pre-existing floating IPs manually.
 * `router_enable`: If a router should be connected to the private network or not
 * `gateways`: Gateways that should be connected to the router, requires router_enable is set to true
   * `features`: List of features for the gateway

--- a/contrib/terraform/upcloud/modules/kubernetes-cluster/main.tf
+++ b/contrib/terraform/upcloud/modules/kubernetes-cluster/main.tf
@@ -25,24 +25,27 @@ locals {
   ])
 
   lb_backend_servers = flatten([
-    for lb_name, loadbalancer in var.loadbalancers : [
-      for backend_server in loadbalancer.backend_servers : {
-        port        = loadbalancer.target_port
-        lb_name     = lb_name
-        server_name = backend_server
-      }
+    for lb_name, lb in upcloud_loadbalancer.lb : [
+      for target_name, target in var.loadbalancers[lb_name].targets : [
+        for backend_server in target.backend_servers : {
+          loadbalancer_name = lb_name
+          port              = target.target_port
+          target_name       = target_name
+          server_name       = backend_server
+        }
+      ]
     ]
   ])
 
   gateway_connections = flatten([
     for gateway_name, gateway in var.gateways : [
       for connection_name, connection in gateway.connections : {
-          "gateway_id" = upcloud_gateway.gateway[gateway_name].id
-          "gateway_name" = gateway_name
-          "connection_name" = connection_name
-          "type" = connection.type
-          "local_routes" = connection.local_routes
-          "remote_routes" = connection.remote_routes
+        "gateway_id"      = upcloud_gateway.gateway[gateway_name].id
+        "gateway_name"    = gateway_name
+        "connection_name" = connection_name
+        "type"            = connection.type
+        "local_routes"    = connection.local_routes
+        "remote_routes"   = connection.remote_routes
       }
     ]
   ])
@@ -51,14 +54,14 @@ locals {
     for gateway_name, gateway in var.gateways : [
       for connection_name, connection in gateway.connections : [
         for tunnel_name, tunnel in connection.tunnels : {
-          "gateway_id" = upcloud_gateway.gateway[gateway_name].id
-          "gateway_name" = gateway_name
-          "connection_id" = upcloud_gateway_connection.gateway_connection["${gateway_name}-${connection_name}"].id
-          "connection_name" = connection_name
-          "tunnel_name" = tunnel_name
+          "gateway_id"         = upcloud_gateway.gateway[gateway_name].id
+          "gateway_name"       = gateway_name
+          "connection_id"      = upcloud_gateway_connection.gateway_connection["${gateway_name}-${connection_name}"].id
+          "connection_name"    = connection_name
+          "tunnel_name"        = tunnel_name
           "local_address_name" = tolist(upcloud_gateway.gateway[gateway_name].address).0.name
-          "remote_address" = tunnel.remote_address
-          "ipsec_properties" = tunnel.ipsec_properties
+          "remote_address"     = tunnel.remote_address
+          "ipsec_properties"   = tunnel.ipsec_properties
         }
       ]
     ]
@@ -70,39 +73,39 @@ locals {
 
   master_ip = {
     for instance in upcloud_server.master :
-      instance.hostname => {
-        for nic in instance.network_interface :
-          nic.type => nic.ip_address
-        if nic.ip_address != null
-      }
+    instance.hostname => {
+      for nic in instance.network_interface :
+      nic.type => nic.ip_address
+      if nic.ip_address != null
+    }
   }
   worker_ip = {
     for instance in upcloud_server.worker :
-      instance.hostname => {
-        for nic in instance.network_interface :
-          nic.type => nic.ip_address
-        if nic.ip_address != null
-      }
+    instance.hostname => {
+      for nic in instance.network_interface :
+      nic.type => nic.ip_address
+      if nic.ip_address != null
+    }
   }
 
   bastion_ip = {
     for instance in upcloud_server.bastion :
-      instance.hostname => {
-        for nic in instance.network_interface :
-          nic.type => nic.ip_address
-        if nic.ip_address != null
-      }
+    instance.hostname => {
+      for nic in instance.network_interface :
+      nic.type => nic.ip_address
+      if nic.ip_address != null
+    }
   }
 
   node_user_data = {
     for name, machine in var.machines :
-      name => <<EOF
-%{ if ( length(machine.dns_servers != null ? machine.dns_servers : [] ) > 0 ) || ( length(var.dns_servers) > 0 && machine.dns_servers == null ) ~}
+    name => <<EOF
+%{if(length(machine.dns_servers != null ? machine.dns_servers : []) > 0) || (length(var.dns_servers) > 0 && machine.dns_servers == null)~}
 #!/bin/bash
-echo -e "[Resolve]\nDNS=${ join(" ", length(machine.dns_servers != null ? machine.dns_servers : []) > 0 ? machine.dns_servers : var.dns_servers) }" > /etc/systemd/resolved.conf
+echo -e "[Resolve]\nDNS=${join(" ", length(machine.dns_servers != null ? machine.dns_servers : []) > 0 ? machine.dns_servers : var.dns_servers)}" > /etc/systemd/resolved.conf
 
 systemctl restart systemd-resolved
-%{ endif ~}
+%{endif~}
 EOF
   }
 }
@@ -117,8 +120,8 @@ resource "upcloud_network" "private" {
     # TODO: When support for dhcp_dns for private networks are in, remove the user_data and enable it here.
     #       See more here https://github.com/UpCloudLtd/terraform-provider-upcloud/issues/562
     # dhcp_dns           = length(var.private_network_dns) > 0 ? var.private_network_dns : null
-    dhcp               = true
-    family             = "IPv4"
+    dhcp   = true
+    family = "IPv4"
   }
 
   router = var.router_enable ? upcloud_router.router[0].id : null
@@ -196,7 +199,7 @@ resource "upcloud_server" "master" {
     create_password = false
   }
 
-  metadata = local.node_user_data[each.key] != "" || each.value.metadata == true ? true : null
+  metadata  = local.node_user_data[each.key] != "" || each.value.metadata == true ? true : null
   user_data = local.node_user_data[each.key] != "" ? local.node_user_data[each.key] : null
 }
 
@@ -262,7 +265,7 @@ resource "upcloud_server" "worker" {
     create_password = false
   }
 
-  metadata = local.node_user_data[each.key] != "" || each.value.metadata == true ? true : null
+  metadata  = local.node_user_data[each.key] != "" || each.value.metadata == true ? true : null
   user_data = local.node_user_data[each.key] != "" ? local.node_user_data[each.key] : null
 }
 
@@ -294,7 +297,7 @@ resource "upcloud_server" "bastion" {
 
   # Private network interface
   network_interface {
-    type    = "public"
+    type = "public"
   }
 
   firewall = var.firewall_enabled
@@ -318,6 +321,8 @@ resource "upcloud_server" "bastion" {
     keys            = var.ssh_public_keys
     create_password = false
   }
+
+  metadata = local.node_user_data[each.key] != "" || each.value.metadata == true ? true : null
 }
 
 resource "upcloud_firewall_rules" "master" {
@@ -714,15 +719,17 @@ resource "upcloud_firewall_rules" "bastion" {
 }
 
 resource "upcloud_loadbalancer" "lb" {
-  count             = var.loadbalancer_enabled ? 1 : 0
+
+  for_each = var.loadbalancer_enabled ? var.loadbalancers : {}
+
   configured_status = "started"
-  name              = "${local.resource-prefix}lb"
-  plan              = var.loadbalancer_plan
+  name              = "${local.resource-prefix}${each.key}-lb"
+  plan              = each.value.plan
   zone              = var.private_cloud ? var.public_zone : var.zone
-  network           = var.loadbalancer_legacy_network ? upcloud_network.private.id : null
+  network           = each.value.legacy_network ? upcloud_network.private.id : null
 
   dynamic "networks" {
-    for_each = var.loadbalancer_legacy_network ? [] : [1]
+    for_each = each.value.private_network ? [1] : []
 
     content {
       name    = "Private-Net"
@@ -732,8 +739,18 @@ resource "upcloud_loadbalancer" "lb" {
     }
   }
 
+  ip_addresses = (
+    try(each.value.floating_ip, null) != null &&
+    try(each.value.floating_ip_network_name, null) != null
+    ) ? [
+    {
+      address      = each.value.floating_ip
+      network_name = each.value.floating_ip_network_name
+    }
+  ] : []
+
   dynamic "networks" {
-    for_each = var.loadbalancer_legacy_network ? [] : [1]
+    for_each = each.value.public_network ? [1] : []
 
     content {
       name   = "Public-Net"
@@ -743,41 +760,50 @@ resource "upcloud_loadbalancer" "lb" {
   }
 
   lifecycle {
-    ignore_changes = [ maintenance_dow, maintenance_time ]
+    ignore_changes = [maintenance_dow, maintenance_time]
   }
 }
 
 resource "upcloud_loadbalancer_backend" "lb_backend" {
-  for_each = var.loadbalancer_enabled ? var.loadbalancers : {}
 
-  loadbalancer = upcloud_loadbalancer.lb[0].id
-  name         = "lb-backend-${each.key}"
+  for_each = {
+    for be_target in local.lb_targets :
+    "${be_target.loadbalancer_name}-${be_target.name}" => be_target
+    if var.loadbalancer_enabled
+  }
+  loadbalancer = each.value.loadbalancer_id
+
+  name = "lb-backend-${each.value.name}"
   properties {
     outbound_proxy_protocol = each.value.proxy_protocol ? "v2" : ""
   }
 }
 
 resource "upcloud_loadbalancer_frontend" "lb_frontend" {
-  for_each = var.loadbalancer_enabled ? var.loadbalancers : {}
+  for_each = {
+    for be_target in local.lb_targets :
+    "${be_target.loadbalancer_name}-${be_target.name}" => be_target
+    if var.loadbalancer_enabled
+  }
 
-  loadbalancer         = upcloud_loadbalancer.lb[0].id
-  name                 = "lb-frontend-${each.key}"
+  loadbalancer         = each.value.loadbalancer_id
+  name                 = "lb-frontend-${each.value.name}"
   mode                 = "tcp"
   port                 = each.value.port
-  default_backend_name = upcloud_loadbalancer_backend.lb_backend[each.key].name
+  default_backend_name = upcloud_loadbalancer_backend.lb_backend["${each.value.loadbalancer_name}-${each.value.name}"].name
 
   dynamic "networks" {
-    for_each = var.loadbalancer_legacy_network ? [] : [1]
+    for_each = each.value.listen_public ? [1] : []
 
     content {
-      name   = "Public-Net"
+      name = "Public-Net"
     }
   }
 
   dynamic "networks" {
-    for_each = each.value.allow_internal_frontend ? [1] : []
+    for_each = each.value.listen_private ? [1] : []
 
-    content{
+    content {
       name = "Private-Net"
     }
   }
@@ -786,16 +812,16 @@ resource "upcloud_loadbalancer_frontend" "lb_frontend" {
 resource "upcloud_loadbalancer_static_backend_member" "lb_backend_member" {
   for_each = {
     for be_server in local.lb_backend_servers :
-    "${be_server.server_name}-lb-backend-${be_server.lb_name}" => be_server
+    "${be_server.loadbalancer_name}-${be_server.server_name}-lb-backend-${be_server.target_name}" => be_server
     if var.loadbalancer_enabled
   }
 
-  backend      = upcloud_loadbalancer_backend.lb_backend[each.value.lb_name].id
-  name         = "${local.resource-prefix}${each.key}"
+  backend      = upcloud_loadbalancer_backend.lb_backend["${each.value.loadbalancer_name}-${each.value.target_name}"].id
+  name         = "${local.resource-prefix}${each.value.server_name}-lb-backend-${each.value.target_name}"
   ip           = merge(local.master_ip, local.worker_ip)["${local.resource-prefix}${each.value.server_name}"].private
   port         = each.value.port
   weight       = 100
-  max_sessions = var.loadbalancer_plan == "production-small" ? 50000 : 1000
+  max_sessions = var.loadbalancers[each.value.loadbalancer_name].plan == "production-small" ? 50000 : 1000
   enabled      = true
 }
 
@@ -805,7 +831,7 @@ resource "upcloud_server_group" "server_groups" {
   anti_affinity_policy = each.value.anti_affinity_policy
   labels               = {}
   # Managed upstream via upcloud_server resource
-  members              = []
+  members = []
   lifecycle {
     ignore_changes = [members]
   }
@@ -823,7 +849,7 @@ resource "upcloud_router" "router" {
       name = static_route.key
 
       nexthop = static_route.value["nexthop"]
-      route = static_route.value["route"]
+      route   = static_route.value["route"]
     }
   }
 
@@ -831,11 +857,11 @@ resource "upcloud_router" "router" {
 
 resource "upcloud_gateway" "gateway" {
   for_each = var.router_enable ? var.gateways : {}
-  name = "${local.resource-prefix}${each.key}-gateway"
-  zone = var.private_cloud ? var.public_zone : var.zone
+  name     = "${local.resource-prefix}${each.key}-gateway"
+  zone     = var.private_cloud ? var.public_zone : var.zone
 
   features = each.value.features
-  plan = each.value.plan
+  plan     = each.value.plan
 
   router {
     id = upcloud_router.router[0].id
@@ -848,8 +874,8 @@ resource "upcloud_gateway_connection" "gateway_connection" {
   }
 
   gateway = each.value.gateway_id
-  name = "${local.resource-prefix}${each.key}-gateway-connection"
-  type = each.value.type
+  name    = "${local.resource-prefix}${each.key}-gateway-connection"
+  type    = each.value.type
 
   dynamic "local_route" {
     for_each = each.value.local_routes
@@ -877,30 +903,30 @@ resource "upcloud_gateway_connection_tunnel" "gateway_connection_tunnel" {
     for gct in local.gateway_connection_tunnels : "${gct.gateway_name}-${gct.connection_name}-${gct.tunnel_name}-tunnel" => gct
   }
 
-  connection_id = each.value.connection_id
-  name = each.key
+  connection_id      = each.value.connection_id
+  name               = each.key
   local_address_name = each.value.local_address_name
-  remote_address = each.value.remote_address
+  remote_address     = each.value.remote_address
 
   ipsec_auth_psk {
     psk = var.gateway_vpn_psks[each.key].psk
   }
 
   dynamic "ipsec_properties" {
-    for_each = each.value.ipsec_properties != null ? { "ip": each.value.ipsec_properties } : {}
+    for_each = each.value.ipsec_properties != null ? { "ip" : each.value.ipsec_properties } : {}
 
     content {
-        child_rekey_time = ipsec_properties.value["child_rekey_time"]
-        dpd_delay = ipsec_properties.value["dpd_delay"]
-        dpd_timeout = ipsec_properties.value["dpd_timeout"]
-        ike_lifetime = ipsec_properties.value["ike_lifetime"]
-        rekey_time = ipsec_properties.value["rekey_time"]
-        phase1_algorithms = ipsec_properties.value["phase1_algorithms"]
-        phase1_dh_group_numbers = ipsec_properties.value["phase1_dh_group_numbers"]
-        phase1_integrity_algorithms = ipsec_properties.value["phase1_integrity_algorithms"]
-        phase2_algorithms = ipsec_properties.value["phase2_algorithms"]
-        phase2_dh_group_numbers = ipsec_properties.value["phase2_dh_group_numbers"]
-        phase2_integrity_algorithms = ipsec_properties.value["phase2_integrity_algorithms"]
+      child_rekey_time            = ipsec_properties.value["child_rekey_time"]
+      dpd_delay                   = ipsec_properties.value["dpd_delay"]
+      dpd_timeout                 = ipsec_properties.value["dpd_timeout"]
+      ike_lifetime                = ipsec_properties.value["ike_lifetime"]
+      rekey_time                  = ipsec_properties.value["rekey_time"]
+      phase1_algorithms           = ipsec_properties.value["phase1_algorithms"]
+      phase1_dh_group_numbers     = ipsec_properties.value["phase1_dh_group_numbers"]
+      phase1_integrity_algorithms = ipsec_properties.value["phase1_integrity_algorithms"]
+      phase2_algorithms           = ipsec_properties.value["phase2_algorithms"]
+      phase2_dh_group_numbers     = ipsec_properties.value["phase2_dh_group_numbers"]
+      phase2_integrity_algorithms = ipsec_properties.value["phase2_integrity_algorithms"]
     }
   }
 }

--- a/contrib/terraform/upcloud/modules/kubernetes-cluster/variables.tf
+++ b/contrib/terraform/upcloud/modules/kubernetes-cluster/variables.tf
@@ -119,11 +119,24 @@ variable "loadbalancers" {
   description = "Load balancers"
 
   type = map(object({
-    proxy_protocol          = bool
-    port                    = number
-    target_port             = number
-    allow_internal_frontend = optional(bool)
-    backend_servers         = list(string)
+
+    plan            = string
+    legacy_network  = bool
+    public_network  = bool
+    private_network    = bool
+    create_floating_ip = optional(bool, false)
+    ip_addresses = optional(list(object({
+      address      = string
+      network_name = string
+    })), [])
+    targets = map(object({
+      proxy_protocol  = bool
+      port            = number
+      target_port     = number
+      listen_public   = bool
+      listen_private  = bool
+      backend_servers = list(string)
+    }))
   }))
 }
 

--- a/contrib/terraform/upcloud/variables.tf
+++ b/contrib/terraform/upcloud/variables.tf
@@ -169,11 +169,24 @@ variable "loadbalancers" {
   description = "Load balancers"
 
   type = map(object({
-    proxy_protocol          = bool
-    port                    = number
-    target_port             = number
-    allow_internal_frontend = optional(bool, false)
-    backend_servers         = list(string)
+
+    plan            = string
+    legacy_network  = bool
+    public_network  = bool
+    private_network = bool
+    create_floating_ip = optional(bool, false)
+    ip_addresses = optional(list(object({
+      address      = string
+      network_name = string
+    })), [])
+    targets = map(object({
+      proxy_protocol  = bool
+      port            = number
+      target_port     = number
+      listen_public   = bool
+      listen_private  = bool
+      backend_servers = list(string)
+    }))
   }))
   default = {}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

- [x] kind feature
- [x] kind admin-change

**What this PR does / why we need it**:

***Background***

UpCloud does not support Cluster API, so Kubernetes clusters are provisioned using Terraform for infrastructure creation and Kubespray for cluster bootstrapping.

UpCloud provides CSI support, enabling dynamic volume provisioning via PVCs, but there is no cloud controller manager. Consequently:

- Kubernetes `Service type=LoadBalancer` cannot be used.
- Load balancers are provisioned directly via Terraform.
- Worker nodes are registered as backends.
- Ingress is exposed via `NodePort`, fronted by the Terraform-managed load balancer.

Until now, UpCloud load balancers exposed only a stable DNS name. While the DNS name is persistent, it does not provide a stable IP address suitable for firewall whitelisting in customer environments.

***Problem***

Customers require stable IP addresses to whitelist cluster ingress endpoints.

***Solution***

UpCloud introduced support for attaching floating IPs directly to load balancers.

***This PR:***

- Upgrades the UpCloud Terraform provider to a version supporting `ip_addresses` on `upcloud_loadbalancer`
- Extends the `loadbalancers` variable schema with two optional fields:
  - `create_floating_ip = optional(bool, false)` — lets Terraform create and manage the floating IP automatically
  - `ip_addresses = optional(list(object({...})), [])` — allows attaching pre-existing floating IPs manually
- When `create_floating_ip = true`, Terraform creates a `upcloud_floating_ip_address` resource and wires it into the LB automatically
- When `ip_addresses` is set, pre-existing floating IPs are attached directly
- Existing configurations without either field remain unaffected

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Floating IPs can now be attached to UpCloud Load Balancers in two ways:

**Option A — Terraform managed (recommended):**
```hcl
loadbalancers = {
  apiserver = {
    plan               = "development"
    public_network     = true
    private_network    = true
    create_floating_ip = true

    targets = {
      kubernetes_api = {
        proxy_protocol  = false
        port            = 6443
        target_port     = 6443
        listen_public   = true
        listen_private  = true
        backend_servers = ["control-plane-0"]
      }
    }
  }
}
```

**Option B — Pre-existing floating IP:**
```hcl
loadbalancers = {
  apiserver = {
    plan            = "development"
    public_network  = true
    private_network = true
    ip_addresses    = [{ address = "xx.xx.xxx.xx", network_name = "Public-Net" }]

    targets = { ... }
  }
}
```

- No migration steps are required.
- Existing configurations without either field remain unaffected.

***How to test:***
1. Set `create_floating_ip = true` in your `cluster.tfvars`
2. Run:
```
terraform init
terraform plan -var-file=cluster.tfvars
terraform apply -var-file=cluster.tfvars
```
3. Verify the floating IP was created and attached:
```
terraform state show 'module.kubernetes.upcloud_floating_ip_address.lb_floating_ip["apiserver"]'
```
4. Verify traffic routes through it:
```
curl -k https://<floating-ip>:6443
```
Expected response is a 403 from the Kubernetes API, confirming traffic is successfully routed through the floating IP and load balancer.

**References:**
- [[UpCloud Floating IP Address - Terraform Provider Docs](https://registry.terraform.io/providers/UpCloudLtd/upcloud/latest/docs/resources/floating_ip_address)](https://registry.terraform.io/providers/UpCloudLtd/upcloud/latest/docs/resources/floating_ip_address)

**Does this PR introduce a user-facing change?**:

Yes, admin-facing change, no changes for end-users.

- Admins can optionally set `create_floating_ip = true` to have Terraform manage the floating IP lifecycle.
- Admins can optionally set `ip_addresses` to attach pre-existing floating IPs.
- If neither is set, behaviour remains unchanged.