### PR TITLE
feat(terraform/upcloud): create and attach floating IPs to load balancers

### DIFF
--- a/contrib/terraform/upcloud/README.md
+++ b/contrib/terraform/upcloud/README.md
@@ -115,6 +115,8 @@ terraform destroy --var-file cluster-settings.tfvars \
   * `target_port`: Port to the backend servers.
   * `backend_servers`: List of servers that traffic to the port should be forwarded to.
   * `proxy_protocol`: If the loadbalancer should set up the backend using proxy protocol.
+  * `create_floating_ip`: Create floating IP, managed by Terraform automatically.
+  * `ip_addresses`: Allow attaching pre-existing floating IPs manually.
 * `router_enable`: If a router should be connected to the private network or not
 * `gateways`: Gateways that should be connected to the router, requires router_enable is set to true
   * `features`: List of features for the gateway

--- a/contrib/terraform/upcloud/modules/kubernetes-cluster/main.tf
+++ b/contrib/terraform/upcloud/modules/kubernetes-cluster/main.tf
@@ -713,8 +713,17 @@ resource "upcloud_firewall_rules" "bastion" {
   }
 }
 
+resource "upcloud_floating_ip_address" "lb_floating_ip" {
+  for_each = {
+    for name, loadbalancer in var.loadbalancers : name => loadbalancer
+    if var.loadbalancer_enabled && try(loadbalancer.create_floating_ip, false)
+  }
+  zone = var.private_cloud ? var.public_zone : var.zone
+}
+
 resource "upcloud_loadbalancer" "lb" {
-  count             = var.loadbalancer_enabled ? 1 : 0
+  for_each = var.loadbalancer_enabled ? var.loadbalancers : {}
+
   configured_status = "started"
   name              = "${local.resource-prefix}lb"
   plan              = var.loadbalancer_plan
@@ -731,6 +740,13 @@ resource "upcloud_loadbalancer" "lb" {
       network = upcloud_network.private.id
     }
   }
+
+  ip_addresses = concat(try(each.value.create_floating_ip, false) ? [
+    {
+      address      = upcloud_floating_ip_address.lb_floating_ip[each.key].ip_address
+      network_name = "Public-Net"
+    }
+  ] : [], each.value.ip_addresses)
 
   dynamic "networks" {
     for_each = var.loadbalancer_legacy_network ? [] : [1]

--- a/contrib/terraform/upcloud/modules/kubernetes-cluster/variables.tf
+++ b/contrib/terraform/upcloud/modules/kubernetes-cluster/variables.tf
@@ -124,6 +124,11 @@ variable "loadbalancers" {
     target_port             = number
     allow_internal_frontend = optional(bool)
     backend_servers         = list(string)
+    create_floating_ip = optional(bool, false)
+    ip_addresses = optional(list(object({
+      address      = string
+      network_name = string
+    })), [])
   }))
 }
 

--- a/contrib/terraform/upcloud/variables.tf
+++ b/contrib/terraform/upcloud/variables.tf
@@ -174,7 +174,13 @@ variable "loadbalancers" {
     target_port             = number
     allow_internal_frontend = optional(bool, false)
     backend_servers         = list(string)
+    create_floating_ip = optional(bool, false)
+    ip_addresses = optional(list(object({
+      address      = string
+      network_name = string
+    })), [])
   }))
+
   default = {}
 }
 


### PR DESCRIPTION


**What type of PR is this?**

- [x] kind feature
- [x] kind admin-change

**What this PR does / why we need it**:

***Background***

UpCloud does not support Cluster API, so Kubernetes clusters are provisioned using Terraform for infrastructure creation and Kubespray for cluster bootstrapping.

UpCloud provides CSI support, enabling dynamic volume provisioning via PVCs, but there is no cloud controller manager. Consequently:

- Kubernetes `Service type=LoadBalancer` cannot be used.
- Load balancers are provisioned directly via Terraform.
- Worker nodes are registered as backends.
- Ingress is exposed via `NodePort`, fronted by the Terraform-managed load balancer.

Until now, UpCloud load balancers exposed only a stable DNS name. While the DNS name is persistent, it does not provide a stable IP address suitable for firewall whitelisting in customer environments.

***Problem***

Customers require stable IP addresses to whitelist cluster ingress endpoints.

***Solution***

UpCloud introduced support for attaching floating IPs directly to load balancers.

***This PR:***

- Upgrades the UpCloud Terraform provider to a version supporting `ip_addresses` on `upcloud_loadbalancer`
- Extends the `loadbalancers` variable schema with two optional fields:
  - `create_floating_ip = optional(bool, false)` — lets Terraform create and manage the floating IP automatically
  - `ip_addresses = optional(list(object({...})), [])` — allows attaching pre-existing floating IPs manually
- When `create_floating_ip = true`, Terraform creates a `upcloud_floating_ip_address` resource and wires it into the LB automatically
- When `ip_addresses` is set, pre-existing floating IPs are attached directly
- Existing configurations without either field remain unaffected

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Floating IPs can now be attached to UpCloud Load Balancers in two ways:

**Option A — Terraform managed (recommended):**
```hcl
loadbalancers = {
  apiserver = {
    plan               = "development"
    public_network     = true
    private_network    = true
    create_floating_ip = true

    targets = {
      kubernetes_api = {
        proxy_protocol  = false
        port            = 6443
        target_port     = 6443
        listen_public   = true
        listen_private  = true
        backend_servers = ["control-plane-0"]
      }
    }
  }
}
```

**Option B — Pre-existing floating IP:**
```hcl
loadbalancers = {
  apiserver = {
    plan            = "development"
    public_network  = true
    private_network = true
    ip_addresses    = [{ address = "xx.xx.xxx.xx", network_name = "Public-Net" }]

    targets = { ... }
  }
}
```

- No migration steps are required.
- Existing configurations without either field remain unaffected.

***How to test:***
1. Set `create_floating_ip = true` in your `cluster.tfvars`
2. Run:
```
terraform init
terraform plan -var-file=cluster.tfvars
terraform apply -var-file=cluster.tfvars
```
3. Verify the floating IP was created and attached:
```
terraform state show 'module.kubernetes.upcloud_floating_ip_address.lb_floating_ip["apiserver"]'
```
4. Verify traffic routes through it:
```
curl -k https://<floating-ip>:6443
```
Expected response is a 403 from the Kubernetes API, confirming traffic is successfully routed through the floating IP and load balancer.

**References:**
- [[UpCloud Floating IP Address - Terraform Provider Docs](https://registry.terraform.io/providers/UpCloudLtd/upcloud/latest/docs/resources/floating_ip_address)](https://registry.terraform.io/providers/UpCloudLtd/upcloud/latest/docs/resources/floating_ip_address)

**Does this PR introduce a user-facing change?**:

Yes, admin-facing change, no changes for end-users.

- Admins can optionally set `create_floating_ip = true` to have Terraform manage the floating IP lifecycle.
- Admins can optionally set `ip_addresses` to attach pre-existing floating IPs.
- If neither is set, behaviour remains unchanged.