### PR TITLE
Joy/floating ips lb release 2.30.0 ck8s

### DIFF
--- a/contrib/terraform/upcloud/README.md
+++ b/contrib/terraform/upcloud/README.md
@@ -116,6 +116,8 @@ terraform destroy --var-file cluster-settings.tfvars \
   * `backend_servers`: List of servers that traffic to the port should be forwarded to.
   * `proxy_protocol`: If the loadbalancer should set up the backend using proxy protocol.
   * `allowed_cidrs`: List of CIDRs that should be allowlisted. If empty or missing, all traffic is allowed.
+  * `create_floating_ip`: Create floating IP, managed by Terraform automatically.
+  * `ip_addresses`: Allow attaching pre-existing floating IPs manually.
 * `router_enable`: If a router should be connected to the private network or not
 * `gateways`: Gateways that should be connected to the router, requires router_enable is set to true
   * `features`: List of features for the gateway

--- a/contrib/terraform/upcloud/modules/kubernetes-cluster/main.tf
+++ b/contrib/terraform/upcloud/modules/kubernetes-cluster/main.tf
@@ -344,6 +344,8 @@ resource "upcloud_server" "bastion" {
     keys            = var.ssh_public_keys
     create_password = false
   }
+
+  metadata = local.node_user_data[each.key] != "" || each.value.metadata == true ? true : null
 }
 
 resource "upcloud_firewall_rules" "master" {
@@ -739,8 +741,15 @@ resource "upcloud_firewall_rules" "bastion" {
   }
 }
 
-resource "upcloud_loadbalancer" "lb" {
+resource "upcloud_floating_ip_address" "lb_floating_ip" {
+  for_each = {
+    for name, loadbalancer in var.loadbalancers : name => loadbalancer
+    if var.loadbalancer_enabled && try(loadbalancer.create_floating_ip, false)
+  }
+  zone = var.private_cloud ? var.public_zone : var.zone
+}
 
+resource "upcloud_loadbalancer" "lb" {
   for_each = var.loadbalancer_enabled ? var.loadbalancers : {}
 
   configured_status = "started"
@@ -759,6 +768,13 @@ resource "upcloud_loadbalancer" "lb" {
       network = upcloud_network.private.id
     }
   }
+
+  ip_addresses = concat(try(each.value.create_floating_ip, false) ? [
+    {
+      address      = upcloud_floating_ip_address.lb_floating_ip[each.key].ip_address
+      network_name = "Public-Net"
+    }
+  ] : [], each.value.ip_addresses)
 
   dynamic "networks" {
     for_each = each.value.public_network ? [1] : []
@@ -861,7 +877,7 @@ resource "upcloud_loadbalancer_frontend" "lb_frontend" {
     }
   }
 
-   properties {
+  properties {
     http2_enabled          = false
     inbound_proxy_protocol = false
     timeout_client         = 10

--- a/contrib/terraform/upcloud/modules/kubernetes-cluster/variables.tf
+++ b/contrib/terraform/upcloud/modules/kubernetes-cluster/variables.tf
@@ -113,8 +113,12 @@ variable "loadbalancers" {
     plan            = string
     legacy_network  = bool
     public_network  = bool
-    private_network = bool
-
+    private_network    = bool
+    create_floating_ip = optional(bool, false)
+    ip_addresses = optional(list(object({
+      address      = string
+      network_name = string
+    })), [])
     targets = map(object({
       proxy_protocol  = bool
       port            = number

--- a/contrib/terraform/upcloud/variables.tf
+++ b/contrib/terraform/upcloud/variables.tf
@@ -162,7 +162,11 @@ variable "loadbalancers" {
     legacy_network  = bool
     public_network  = bool
     private_network = bool
-
+    create_floating_ip = optional(bool, false)
+    ip_addresses = optional(list(object({
+      address      = string
+      network_name = string
+    })), [])
     targets = map(object({
       proxy_protocol  = bool
       port            = number


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md and developer guide https://git.k8s.io/community/contributors/devel/development.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

- [x] kind feature
- [x] kind admin-change

**What this PR does / why we need it**:

***Background***

UpCloud does not support Cluster API, so Kubernetes clusters are provisioned using Terraform for infrastructure creation and Kubespray for cluster bootstrapping.

UpCloud provides CSI support, enabling dynamic volume provisioning via PVCs, but there is no cloud controller manager. Consequently:

- Kubernetes `Service type=LoadBalancer` cannot be used.
- Load balancers are provisioned directly via Terraform.
- Worker nodes are registered as backends.
- Ingress is exposed via `NodePort`, fronted by the Terraform-managed load balancer.

Until now, UpCloud load balancers exposed only a stable DNS name. While the DNS name is persistent, it does not provide a stable IP address suitable for firewall whitelisting in customer environments.

***Problem***

Customers require stable IP addresses to whitelist cluster ingress endpoints.

***Solution***

UpCloud introduced support for attaching floating IPs directly to load balancers.

***This PR:***

- Upgrades the UpCloud Terraform provider to a version supporting `ip_addresses` on `upcloud_loadbalancer`
- Extends the `loadbalancers` variable schema with two optional fields:
  - `create_floating_ip = optional(bool, false)` — lets Terraform create and manage the floating IP automatically
  - `ip_addresses = optional(list(object({...})), [])` — allows attaching pre-existing floating IPs manually
- When `create_floating_ip = true`, Terraform creates a `upcloud_floating_ip_address` resource and wires it into the LB automatically
- When `ip_addresses` is set, pre-existing floating IPs are attached directly
- Existing configurations without either field remain unaffected

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Floating IPs can now be attached to UpCloud Load Balancers in two ways:

**Option A — Terraform managed (recommended):**
```hcl
loadbalancers = {
  apiserver = {
    plan               = "development"
    public_network     = true
    private_network    = true
    create_floating_ip = true

    targets = {
      kubernetes_api = {
        proxy_protocol  = false
        port            = 6443
        target_port     = 6443
        listen_public   = true
        listen_private  = true
        backend_servers = ["control-plane-0"]
      }
    }
  }
}
```

**Option B — Pre-existing floating IP:**
```hcl
loadbalancers = {
  apiserver = {
    plan            = "development"
    public_network  = true
    private_network = true
    ip_addresses    = [{ address = "xx.xx.xxx.xx", network_name = "Public-Net" }]

    targets = { ... }
  }
}
```

- No migration steps are required.
- Existing configurations without either field remain unaffected.

***How to test:***
1. Set `create_floating_ip = true` in your `cluster.tfvars`
2. Run:
```
terraform init
terraform plan -var-file=cluster.tfvars
terraform apply -var-file=cluster.tfvars
```
3. Verify the floating IP was created and attached:
```
terraform state show 'module.kubernetes.upcloud_floating_ip_address.lb_floating_ip["apiserver"]'
```
4. Verify traffic routes through it:
```
curl -k https://<floating-ip>:6443
```
Expected response is a 403 from the Kubernetes API, confirming traffic is successfully routed through the floating IP and load balancer.

**References:**
- [[UpCloud Floating IP Address - Terraform Provider Docs](https://registry.terraform.io/providers/UpCloudLtd/upcloud/latest/docs/resources/floating_ip_address)](https://registry.terraform.io/providers/UpCloudLtd/upcloud/latest/docs/resources/floating_ip_address)

**Does this PR introduce a user-facing change?**:

Yes, admin-facing change, no changes for end-users.

- Admins can optionally set `create_floating_ip = true` to have Terraform manage the floating IP lifecycle.
- Admins can optionally set `ip_addresses` to attach pre-existing floating IPs.
- If neither is set, behaviour remains unchanged.